### PR TITLE
TASK: Update to latest Fluid and fix CommandReference generation

### DIFF
--- a/Classes/ViewHelpers/Format/IndentViewHelper.php
+++ b/Classes/ViewHelpers/Format/IndentViewHelper.php
@@ -18,14 +18,24 @@ namespace Neos\DocTools\ViewHelpers\Format;
 class IndentViewHelper extends \Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper
 {
     /**
-     * @param string $indent String used to indent
-     * @param boolean $inline If TRUE, the first line will not be indented
+     * Initialize the arguments.
+     *
+     * @return void
+     * @api
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('indent', 'string', 'String used to indent', false, "\t");
+        $this->registerArgument('inline', 'boolean', 'If true, the first line will not be indented', false, false);
+    }
+
+    /**
      * @return string The formatted value
      */
-    public function render($indent = "\t", $inline = false)
+    public function render()
     {
         $string = $this->renderChildren();
 
-        return ($inline === false ? $indent : '') . str_replace("\n", "\n" . $indent, $string);
+        return ($this->arguments['inline'] === false ? $this->arguments['indent'] : '') . str_replace("\n", "\n" . $this->arguments['indent'], $string);
     }
 }

--- a/Classes/ViewHelpers/Format/UnderlineViewHelper.php
+++ b/Classes/ViewHelpers/Format/UnderlineViewHelper.php
@@ -18,13 +18,23 @@ namespace Neos\DocTools\ViewHelpers\Format;
 class UnderlineViewHelper extends \Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper
 {
     /**
-     * @param string $withCharacter The padding string
+     * Initialize the arguments.
+     *
+     * @return void
+     * @api
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('withCharacter', 'string', 'The padding string', false, '-');
+    }
+
+    /**
      * @return string The formatted value
      */
-    public function render($withCharacter = '-')
+    public function render()
     {
         $string = $this->renderChildren();
 
-        return $string . chr(10) . str_repeat($withCharacter, strlen($string));
+        return $string . chr(10) . str_repeat($this->arguments['withCharacter'], strlen($string));
     }
 }


### PR DESCRIPTION
ViewHelpers no longer take arguments on the `render()` method. Also, the `buildCommandsIndex()` method was missing since the refactor to no longer inherit HelpCommandController.